### PR TITLE
Centralize API base url

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -2,8 +2,9 @@
 import axios from 'axios';
 import { store } from '../store';
 import { addPendingRequest } from '../slices/queueSlice';
+import { BASE_URL } from '../config';
 
-const api = axios.create({ baseURL: 'https://dicsapps.space:3005/api' });
+const api = axios.create({ baseURL: BASE_URL });
 
 api.interceptors.request.use(config => {
   const token = store.getState().auth.token;

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,1 @@
+export const BASE_URL = process.env.BASE_URL || 'https://dicsapps.space:3005/api';

--- a/src/slices/articulosSlice.js
+++ b/src/slices/articulosSlice.js
@@ -1,9 +1,10 @@
 
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
+import { BASE_URL } from '../config';
 
 export const fetchArticulos = createAsyncThunk('articulos/fetch', async (token) => {
-  const { data } = await axios.get('https://dicsapps.space:3005/api/articulos', {
+  const { data } = await axios.get(`${BASE_URL}/articulos`, {
     headers: { Authorization: `Bearer ${token}` }
   });
   return data;

--- a/src/slices/authSlice.js
+++ b/src/slices/authSlice.js
@@ -1,8 +1,9 @@
 
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
+import { BASE_URL } from '../config';
 
-const API = axios.create({ baseURL: 'https://dicsapps.space:3005/api' });
+const API = axios.create({ baseURL: BASE_URL });
 
 export const login = createAsyncThunk('auth/login', async ({ username, password }) => {
   const { data } = await API.post('/auth/login', { username, password });

--- a/src/slices/clientsSlice.js
+++ b/src/slices/clientsSlice.js
@@ -1,9 +1,10 @@
 
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
+import { BASE_URL } from '../config';
 
 export const fetchClients = createAsyncThunk('clients/fetch', async (token) => {
-  const { data } = await axios.get('https://dicsapps.space:3005/api/clients', {
+  const { data } = await axios.get(`${BASE_URL}/clients`, {
     headers: { Authorization: `Bearer ${token}` }
   });
   return data;

--- a/src/slices/queueSlice.js
+++ b/src/slices/queueSlice.js
@@ -1,6 +1,7 @@
 // src/slices/queueSlice.js
 import { createSlice, nanoid } from '@reduxjs/toolkit';
 import axios from 'axios';
+import { BASE_URL } from '../config';
 
 // Creamos el slice "queue"
 const queueSlice = createSlice({
@@ -45,7 +46,7 @@ export const flushQueue = () => async (dispatch, getState) => {
 
   // Creamos instancia de axios con el token
   const api = axios.create({
-    baseURL: 'https://dicsapps.space:3005/api',
+    baseURL: BASE_URL,
     headers: { Authorization: `Bearer ${token}` }
   });
 


### PR DESCRIPTION
## Summary
- add `src/config.js` for shared base url
- use `BASE_URL` in API utilities and Redux slices

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68420ac2566c832fb1c7ef12b2ede8af