### PR TITLE
Add JWT expiration checks

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -2,13 +2,19 @@
 import axios from 'axios';
 import { store } from '../store';
 import { addPendingRequest } from '../slices/queueSlice';
+import { logout } from '../slices/authSlice';
 import { API_BASE_URL } from '../config';
+import { isJwtExpired } from '../utils/jwt';
 
 const api = axios.create({ baseURL: API_BASE_URL });
 
 api.interceptors.request.use(config => {
   const token = store.getState().auth.token;
   if (token) {
+    if (isJwtExpired(token)) {
+      store.dispatch(logout());
+      return Promise.reject(new Error('Token expired'));
+    }
     config.headers.Authorization = `Bearer ${token}`;
   }
   return config;

--- a/src/navigation/MainNavigator.js
+++ b/src/navigation/MainNavigator.js
@@ -1,18 +1,29 @@
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import LoginScreen from '../screens/LoginScreen';
 import ClientListScreen from '../screens/ClientListScreen';
 import CaptureScreen from '../screens/CaptureScreen';
+import { isJwtExpired } from '../utils/jwt';
+import { logout } from '../slices/authSlice';
 
 const Stack = createStackNavigator();
 
 export default function MainNavigator() {
   const token = useSelector(state => state.auth.token);
+  const dispatch = useDispatch();
+  const isLoggedIn = token && !isJwtExpired(token);
+
+  useEffect(() => {
+    if (token && isJwtExpired(token)) {
+      dispatch(logout());
+    }
+  }, [token, dispatch]);
+
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
-      {token ? (
+      {isLoggedIn ? (
         <>
           <Stack.Screen name="Clients" component={ClientListScreen} />
           <Stack.Screen name="Capture" component={CaptureScreen} />

--- a/src/slices/authSlice.js
+++ b/src/slices/authSlice.js
@@ -2,6 +2,7 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 import { API_BASE_URL } from '../config';
+import { isJwtExpired } from '../utils/jwt';
 
 const API = axios.create({ baseURL: API_BASE_URL });
 
@@ -29,7 +30,12 @@ const authSlice = createSlice({
       })
       .addCase(login.fulfilled, (state, action) => {
         state.status = 'succeeded';
-        state.token = action.payload;
+        if (isJwtExpired(action.payload)) {
+          state.error = 'Token expirado';
+          state.token = null;
+        } else {
+          state.token = action.payload;
+        }
       })
       .addCase(login.rejected, (state, action) => {
         state.status = 'failed';

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,0 +1,24 @@
+import { Buffer } from 'buffer';
+
+export function parseJwt(token) {
+  try {
+    const base64Url = token.split('.')[1];
+    if (!base64Url) {
+      return null;
+    }
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const payload = Buffer.from(base64, 'base64').toString('utf8');
+    return JSON.parse(payload);
+  } catch {
+    return null;
+  }
+}
+
+export function isJwtExpired(token) {
+  const payload = parseJwt(token);
+  if (!payload || typeof payload.exp !== 'number') {
+    return true;
+  }
+  const expiry = payload.exp * 1000;
+  return Date.now() >= expiry;
+}


### PR DESCRIPTION
## Summary
- add JWT helper with expiration validation
- invalidate session if token expired
- reject API requests when token is expired

## Testing
- `npm test -- --config jest.config.js`

------
https://chatgpt.com/codex/tasks/task_b_684216b6e2e4832fb7470119755559a8