### PR TITLE
Improve UI theme and navigation

### DIFF
--- a/src/navigation/MainNavigator.js
+++ b/src/navigation/MainNavigator.js
@@ -7,6 +7,7 @@ import ClientListScreen from '../screens/ClientListScreen';
 import CaptureScreen from '../screens/CaptureScreen';
 import { isJwtExpired } from '../utils/jwt';
 import { logout } from '../slices/authSlice';
+import { colors } from '../theme';
 
 const Stack = createStackNavigator();
 
@@ -22,14 +23,31 @@ export default function MainNavigator() {
   }, [token, dispatch]);
 
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: colors.primary },
+        headerTintColor: colors.white
+      }}
+    >
       {isLoggedIn ? (
         <>
-          <Stack.Screen name="Clients" component={ClientListScreen} />
-          <Stack.Screen name="Capture" component={CaptureScreen} />
+          <Stack.Screen
+            name="Clients"
+            component={ClientListScreen}
+            options={{ title: 'Clientes' }}
+          />
+          <Stack.Screen
+            name="Capture"
+            component={CaptureScreen}
+            options={{ title: 'Registro' }}
+          />
         </>
       ) : (
-        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen
+          name="Login"
+          component={LoginScreen}
+          options={{ headerShown: false }}
+        />
       )}
     </Stack.Navigator>
   );

--- a/src/screens/CaptureScreen.js
+++ b/src/screens/CaptureScreen.js
@@ -6,7 +6,6 @@ import {
   TextInput,
   Button,
   Image,
-  StyleSheet,
   Alert,
   KeyboardAvoidingView,
   ScrollView,
@@ -16,6 +15,8 @@ import {
   Modal,
   FlatList
 } from 'react-native';
+import { colors } from '../theme';
+import styles from '../styles/captureStyles';
 import * as ImagePicker from 'expo-image-picker';
 import { useRoute } from '@react-navigation/native';
 import { useSelector, useDispatch } from 'react-redux';
@@ -199,13 +200,13 @@ export default function CaptureScreen({ navigation }) {
               </View>
             )}
             <View style={styles.photoButtonWrapper}>
-              <Button title="Tomar Foto" onPress={takePhoto} color="#333" />
+              <Button title="Tomar Foto" onPress={takePhoto} color={colors.dark} />
             </View>
           </View>
 
           {/* Botón Guardar */}
           <View style={styles.saveButtonWrapper}>
-            <Button title="Guardar" onPress={handleSave} color="#1f2937" />
+            <Button title="Guardar" onPress={handleSave} color={colors.dark} />
           </View>
         </ScrollView>
       </KeyboardAvoidingView>
@@ -213,159 +214,3 @@ export default function CaptureScreen({ navigation }) {
   );
 }
 
-const styles = StyleSheet.create({
-  safeArea: {
-    flex: 1,
-    backgroundColor: '#f3f4f6'
-  },
-  flex: {
-    flex: 1
-  },
-  container: {
-    padding: 16,
-    paddingBottom: 32
-  },
-  headerContainer: {
-    marginBottom: 24
-  },
-  headerText: {
-    fontSize: 16,
-    color: '#4b5563'
-  },
-  clientName: {
-    fontSize: 22,
-    fontWeight: '600',
-    color: '#1f2937',
-    marginTop: 4
-  },
-
-  // Dropdown “artículo”
-  sectionCard: {
-    backgroundColor: '#ffffff',
-    borderRadius: 8,
-    padding: 12,
-    marginBottom: 20,
-    borderWidth: 1,
-    borderColor: '#e5e7eb'
-  },
-  sectionError: {
-    borderColor: '#dc2626'
-  },
-  sectionLabel: {
-    fontSize: 14,
-    fontWeight: '500',
-    color: '#374151',
-    marginBottom: 8
-  },
-  dropdownInput: {
-    borderWidth: 1,
-    borderColor: '#d1d5db',
-    borderRadius: 6,
-    paddingVertical: 10,
-    paddingHorizontal: 12,
-    backgroundColor: '#fafafa'
-  },
-  dropdownText: {
-    fontSize: 15,
-    color: '#111827'
-  },
-  dropdownPlaceholder: {
-    fontSize: 15,
-    color: '#999'
-  },
-
-  // Modal
-  modalContainer: {
-    flex: 1,
-    backgroundColor: '#ffffff'
-  },
-  modalHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: '#e5e7eb'
-  },
-  modalTitle: {
-    fontSize: 20,
-    fontWeight: '600',
-    color: '#1f2937'
-  },
-  modalCloseButton: {
-    padding: 8
-  },
-  modalCloseText: {
-    fontSize: 16,
-    color: '#2563eb'
-  },
-  modalSearchInput: {
-    borderWidth: 1,
-    borderColor: '#d1d5db',
-    borderRadius: 6,
-    margin: 16,
-    paddingVertical: 8,
-    paddingHorizontal: 12,
-    fontSize: 16,
-    backgroundColor: '#fafafa',
-    color: '#111827'
-  },
-  articuloItem: {
-    paddingVertical: 14,
-    paddingHorizontal: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: '#e5e7eb'
-  },
-  articuloText: {
-    fontSize: 16,
-    color: '#111827'
-  },
-  modalEmpty: {
-    marginTop: 32,
-    alignItems: 'center'
-  },
-  modalEmptyText: {
-    fontSize: 16,
-    color: '#6b7280'
-  },
-
-  // Resto del formulario
-  textInput: {
-    borderWidth: 1,
-    borderColor: '#d1d5db',
-    borderRadius: 6,
-    paddingVertical: 10,
-    paddingHorizontal: 12,
-    fontSize: 15,
-    backgroundColor: '#fafafa',
-    color: '#111827'
-  },
-  photoPreview: {
-    width: '100%',
-    height: 200,
-    borderRadius: 6,
-    marginBottom: 12,
-    backgroundColor: '#e5e7eb'
-  },
-  photoPlaceholder: {
-    width: '100%',
-    height: 200,
-    borderRadius: 6,
-    marginBottom: 12,
-    backgroundColor: '#e5e7eb',
-    justifyContent: 'center',
-    alignItems: 'center'
-  },
-  photoPlaceholderText: {
-    color: '#6b7280',
-    fontSize: 16
-  },
-  photoButtonWrapper: {
-    width: '50%',
-    alignSelf: 'flex-start'
-  },
-  saveButtonWrapper: {
-    marginTop: 10,
-    marginHorizontal: 40
-  }
-});

--- a/src/screens/ClientListScreen.js
+++ b/src/screens/ClientListScreen.js
@@ -6,11 +6,10 @@ import {
   Text,
   TouchableOpacity,
   TextInput,
-  StyleSheet,
   Keyboard
 } from 'react-native';
+import styles from '../styles/clientListStyles';
 import { useDispatch, useSelector } from 'react-redux';
-import NetInfo from '@react-native-community/netinfo';
 import { fetchClients } from '../slices/clientsSlice';
 import { fetchArticulos } from '../slices/articulosSlice';
 import { flushQueue } from '../slices/queueSlice';
@@ -111,79 +110,3 @@ export default function ClientListScreen({ navigation }) {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#f9fafb',
-    padding: 16
-  },
-  headerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 8
-  },
-  title: {
-    fontSize: 22,
-    fontWeight: '600',
-    color: '#1f2937'
-  },
-  badgeContainer: {
-    marginLeft: 8,
-    backgroundColor: '#dc2626',
-    borderRadius: 12,
-    minWidth: 24,
-    height: 24,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: 6
-  },
-  badgeText: {
-    color: '#ffffff',
-    fontSize: 14,
-    fontWeight: '600'
-  },
-  offlineText: {
-    color: '#dc2626',
-    marginBottom: 8,
-    fontSize: 14
-  },
-  searchContainer: {
-    marginBottom: 12
-  },
-  searchInput: {
-    borderWidth: 1,
-    borderColor: '#d1d5db',
-    borderRadius: 6,
-    backgroundColor: '#ffffff',
-    paddingVertical: 10,
-    paddingHorizontal: 12,
-    fontSize: 16,
-    color: '#111827'
-  },
-  item: {
-    backgroundColor: '#ffffff',
-    padding: 16,
-    borderRadius: 6,
-    marginBottom: 8,
-    borderWidth: 1,
-    borderColor: '#e5e7eb'
-  },
-  itemText: {
-    fontSize: 16,
-    fontWeight: '500',
-    color: '#111827'
-  },
-  itemSubText: {
-    fontSize: 13,
-    color: '#6b7280',
-    marginTop: 4
-  },
-  emptyContainer: {
-    marginTop: 32,
-    alignItems: 'center'
-  },
-  emptyText: {
-    fontSize: 16,
-    color: '#6b7280'
-  }
-});

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -1,6 +1,8 @@
 
 import React, { useState } from 'react';
-import { View, TextInput, Button, StyleSheet, Text, Alert } from 'react-native';
+import { View, TextInput, Button, Text, Alert } from 'react-native';
+import { colors } from '../theme';
+import styles from '../styles/loginStyles';
 import { useDispatch, useSelector } from 'react-redux';
 import { login } from '../slices/authSlice';
 
@@ -34,23 +36,12 @@ export default function LoginScreen() {
         secureTextEntry
         style={styles.input}
       />
-      <Button title={status === 'loading' ? 'Cargando...' : 'Entrar'} onPress={handleLogin} />
+      <Button
+        title={status === 'loading' ? 'Cargando...' : 'Entrar'}
+        onPress={handleLogin}
+        color={colors.primary}
+      />
     </View>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    padding: 16,
-  },
-  title: { fontSize: 24, marginBottom: 20, textAlign: 'center' },
-  input: {
-    borderWidth: 1,
-    borderColor: '#ccc',
-    padding: 8,
-    marginBottom: 12,
-    borderRadius: 4
-  }
-});

--- a/src/styles/captureStyles.js
+++ b/src/styles/captureStyles.js
@@ -1,0 +1,159 @@
+import { StyleSheet } from 'react-native';
+import { colors } from '../theme';
+
+export default StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: colors.light
+  },
+  flex: {
+    flex: 1
+  },
+  container: {
+    padding: 16,
+    paddingBottom: 32
+  },
+  headerContainer: {
+    marginBottom: 24
+  },
+  headerText: {
+    fontSize: 16,
+    color: colors.muted
+  },
+  clientName: {
+    fontSize: 22,
+    fontWeight: '600',
+    color: colors.dark,
+    marginTop: 4
+  },
+
+  // Dropdown “artículo”
+  sectionCard: {
+    backgroundColor: colors.white,
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 20,
+    borderWidth: 1,
+    borderColor: colors.border
+  },
+  sectionError: {
+    borderColor: colors.danger
+  },
+  sectionLabel: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: colors.dark,
+    marginBottom: 8
+  },
+  dropdownInput: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 6,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    backgroundColor: colors.light
+  },
+  dropdownText: {
+    fontSize: 15,
+    color: colors.dark
+  },
+  dropdownPlaceholder: {
+    fontSize: 15,
+    color: colors.muted
+  },
+
+  // Modal
+  modalContainer: {
+    flex: 1,
+    backgroundColor: colors.white
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: colors.dark
+  },
+  modalCloseButton: {
+    padding: 8
+  },
+  modalCloseText: {
+    fontSize: 16,
+    color: colors.primary
+  },
+  modalSearchInput: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 6,
+    margin: 16,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    fontSize: 16,
+    backgroundColor: colors.light,
+    color: colors.dark
+  },
+  articuloItem: {
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border
+  },
+  articuloText: {
+    fontSize: 16,
+    color: colors.dark
+  },
+  modalEmpty: {
+    marginTop: 32,
+    alignItems: 'center'
+  },
+  modalEmptyText: {
+    fontSize: 16,
+    color: colors.muted
+  },
+
+  // Resto del formulario
+  textInput: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 6,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    fontSize: 15,
+    backgroundColor: colors.light,
+    color: colors.dark
+  },
+  photoPreview: {
+    width: '100%',
+    height: 200,
+    borderRadius: 6,
+    marginBottom: 12,
+    backgroundColor: colors.border
+  },
+  photoPlaceholder: {
+    width: '100%',
+    height: 200,
+    borderRadius: 6,
+    marginBottom: 12,
+    backgroundColor: colors.border,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  photoPlaceholderText: {
+    color: colors.muted,
+    fontSize: 16
+  },
+  photoButtonWrapper: {
+    width: '50%',
+    alignSelf: 'flex-start'
+  },
+  saveButtonWrapper: {
+    marginTop: 10,
+    marginHorizontal: 40
+  }
+});

--- a/src/styles/clientListStyles.js
+++ b/src/styles/clientListStyles.js
@@ -1,0 +1,79 @@
+import { StyleSheet } from 'react-native';
+import { colors } from '../theme';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    padding: 16
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '600',
+    color: colors.dark
+  },
+  badgeContainer: {
+    marginLeft: 8,
+    backgroundColor: colors.danger,
+    borderRadius: 12,
+    minWidth: 24,
+    height: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 6
+  },
+  badgeText: {
+    color: colors.white,
+    fontSize: 14,
+    fontWeight: '600'
+  },
+  offlineText: {
+    color: colors.danger,
+    marginBottom: 8,
+    fontSize: 14
+  },
+  searchContainer: {
+    marginBottom: 12
+  },
+  searchInput: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 6,
+    backgroundColor: colors.white,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    fontSize: 16,
+    color: colors.dark
+  },
+  item: {
+    backgroundColor: colors.white,
+    padding: 16,
+    borderRadius: 6,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: colors.border
+  },
+  itemText: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: colors.dark
+  },
+  itemSubText: {
+    fontSize: 13,
+    color: colors.muted,
+    marginTop: 4
+  },
+  emptyContainer: {
+    marginTop: 32,
+    alignItems: 'center'
+  },
+  emptyText: {
+    fontSize: 16,
+    color: colors.muted
+  }
+});

--- a/src/styles/loginStyles.js
+++ b/src/styles/loginStyles.js
@@ -1,0 +1,25 @@
+import { StyleSheet } from 'react-native';
+import { colors } from '../theme';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 16,
+    backgroundColor: colors.background
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 20,
+    textAlign: 'center',
+    color: colors.primary
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4,
+    backgroundColor: colors.white
+  }
+});

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,22 @@
+export const colors = {
+  primary: '#0d6efd',
+  secondary: '#6c757d',
+  success: '#198754',
+  danger: '#dc3545',
+  warning: '#ffc107',
+  info: '#0dcaf0',
+  light: '#f8f9fa',
+  dark: '#212529',
+  muted: '#6c757d',
+  background: '#f8f9fa',
+  border: '#dee2e6',
+  white: '#ffffff'
+};
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24
+};


### PR DESCRIPTION
## Summary
- add central theme and color palette
- use the theme in Login, ClientList and Capture screens
- update navigation headers with primary color
- split screen styles into dedicated files for cleaner components

## Testing
- `npm test -- --config jest.config.js`


------
https://chatgpt.com/codex/tasks/task_b_6842189afc60832f93ffaf79f783f5d5