### PR TITLE
Add 'Sin activos' option and rename app

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-  <string name="app_name">nombre-nuevo-proyecto</string>
+  <string name="app_name">INVENTARIO ACTIVOS</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
 </resources>

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -31,7 +31,7 @@ extensions.configure(com.facebook.react.ReactSettingsExtension) { ex ->
 }
 expoAutolinking.useExpoModules()
 
-rootProject.name = 'nombre-nuevo-proyecto'
+rootProject.name = 'inventario-activos'
 
 expoAutolinking.useExpoVersionCatalog()
 

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "nombre-nuevo-proyecto",
-    "slug": "nombre-nuevo-proyecto",
+    "name": "INVENTARIO ACTIVOS",
+    "slug": "inventario-activos",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/backend/controllers/recordController.js
+++ b/backend/controllers/recordController.js
@@ -3,14 +3,14 @@ import pool from '../config/db.js';
 export const createRecord = async (req, res, next) => {
   try {
     const { codcliente, cod_articulo, qty } = req.body;
-    if (!req.file) {
+    if (!req.file && Number(cod_articulo) !== 1) {
       console.warn('No se encontró req.file');
       return res.status(400).json({ message: 'Foto requerida' });
     }
 
     await pool.execute(
       'INSERT INTO records (codcliente, cod_articulo, qty, photo, user_id) VALUES (?, ?, ?, ?, ?)',
-      [codcliente, cod_articulo, qty, req.file.filename, req.user.id]
+      [codcliente, cod_articulo, qty, req.file ? req.file.filename : null, req.user.id]
     );
     res.json({ message: 'Registro guardado' });
   } catch (err) {

--- a/src/slices/queueSlice.js
+++ b/src/slices/queueSlice.js
@@ -19,7 +19,7 @@ const queueSlice = createSlice({
         state.pending.push(action.payload);
       },
       prepare(payload) {
-        // payload debería ser un objeto con { codcliente, cod_articulo, qty, photoUri, photoName, photoType }
+        // payload: { codcliente, cod_articulo, qty, photoUri?, photoName?, photoType? }
         return { payload: { id: nanoid(), ...payload } };
       }
     },
@@ -56,11 +56,13 @@ export const flushQueue = () => async (dispatch, getState) => {
       formData.append('codcliente', item.codcliente);
       formData.append('cod_articulo', item.cod_articulo);
       formData.append('qty', item.qty.toString());
-      formData.append('photo', {
-        uri: item.photoUri,
-        name: item.photoName,
-        type: item.photoType
-      });
+      if (item.photoUri) {
+        formData.append('photo', {
+          uri: item.photoUri,
+          name: item.photoName,
+          type: item.photoType
+        });
+      }
 
       // Enviamos cada petición al endpoint /records
       await api.post('/records', formData, {

--- a/src/styles/captureStyles.js
+++ b/src/styles/captureStyles.js
@@ -62,6 +62,11 @@ export default StyleSheet.create({
     color: colors.muted
   },
 
+  sinActivosWrapper: {
+    alignItems: 'flex-start',
+    marginBottom: 20
+  },
+
   // Modal
   modalContainer: {
     flex: 1,


### PR DESCRIPTION
## Summary
- rename to **INVENTARIO ACTIVOS**
- allow choosing *Sin activos* in the capture form
- auto fill article and quantity for that option
- photo no longer required for *Sin activos*
- support optional photo in backend and queue

## Testing
- `npm test -- --config jest.config.js`

------
https://chatgpt.com/codex/tasks/task_b_6850aadc5ab8832f91bfed5638cfe041